### PR TITLE
Fix tanh bug

### DIFF
--- a/BrainCore.xcodeproj/project.pbxproj
+++ b/BrainCore.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		61CE4BCE1BED6F90000E0D34 /* Upsurge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61CE4BC21BED6F7F000E0D34 /* Upsurge.framework */; };
 		61CE4BCF1BED703B000E0D34 /* Upsurge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61CE4BC21BED6F7F000E0D34 /* Upsurge.framework */; };
 		61CE4BD01BED703F000E0D34 /* Upsurge.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61CE4BC51BED6F7F000E0D34 /* Upsurge.framework */; };
+		8C378A7B1CA3406300D1B153 /* Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C378A7A1CA3406300D1B153 /* Utilities.h */; };
+		8C378A7C1CA3406300D1B153 /* Utilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 8C378A7A1CA3406300D1B153 /* Utilities.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -102,6 +104,7 @@
 		61CE4BC31BED6F7F000E0D34 /* Upsurge.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Upsurge.framework.dSYM; sourceTree = "<group>"; };
 		61CE4BC51BED6F7F000E0D34 /* Upsurge.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Upsurge.framework; sourceTree = "<group>"; };
 		61CE4BC61BED6F7F000E0D34 /* Upsurge.framework.dSYM */ = {isa = PBXFileReference; lastKnownFileType = wrapper.dsym; path = Upsurge.framework.dSYM; sourceTree = "<group>"; };
+		8C378A7A1CA3406300D1B153 /* Utilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Utilities.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,6 +213,7 @@
 				614197FF1C5FEFB700FB6770 /* InnerProduct.metal */,
 				6119AC321C61486D0020E0E6 /* LSTM.metal */,
 				615C96251C5BF91500A1CFD4 /* ReLU.metal */,
+				8C378A7A1CA3406300D1B153 /* Utilities.h */,
 			);
 			path = Metal;
 			sourceTree = "<group>";
@@ -251,6 +255,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6159F8A21BD1F5CE0010F83C /* BrainCore.h in Headers */,
+				8C378A7B1CA3406300D1B153 /* Utilities.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -259,6 +264,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				6159F8AB1BD1F5DB0010F83C /* BrainCore.h in Headers */,
+				8C378A7C1CA3406300D1B153 /* Utilities.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Metal/Utilities.h
+++ b/Source/Metal/Utilities.h
@@ -1,0 +1,39 @@
+// Copyright © 2016 Venture Media Labs. All rights reserved.
+//
+// This file is part of BrainCore. The full BrainCore copyright notice,
+// including terms governing use, modification, and redistribution, is
+// contained in the file LICENSE at the root of the source code distribution
+// tree.
+
+#include <metal_stdlib>
+
+
+inline float safe_tanh(const float x) {
+    const auto P0 = -8.237728127e-1f;
+    const auto P1 = -3.831010665e-3f;
+    const auto Q0 = 2.471319654f;
+    const auto xLarge = 8.66433975699931636772f;
+    const auto xMedium = 5.4930614433405484570e-1f;
+    const auto xSmall = 4.22863966691620432990e-4f;
+
+    const auto sign = x > 0 ? 1 : -1;
+    const auto absX = sign * x;
+
+    if (absX >= xLarge) {
+        return sign;
+    } else if (xMedium <= x) {
+        const auto temp = 0.5 - 1 / (1 + metal::exp(2 * absX));
+        return sign * (temp + temp);
+    } else if (xSmall <= x) {
+        const auto g = absX * absX;
+        const auto R = g * (P1 * g + P0) / (g + Q0);
+        return x + x * R;
+    } else {
+        return sign * absX;
+    }
+}
+
+inline float sigmoid(const float x) {
+    return 1.0 / (1.0 + metal::exp(-x));
+}
+


### PR DESCRIPTION
The metal standard library tanh function causes NaN errors on certain GPUs. We decided it was likely due to the series expansion form of tanh(x), which computes x^7 likely causing overflow. Some GPUs handle NaNs by treating them as zeros, while others do not handle them at all. The tanh implementation we wrote was the single precision algorithm as specified in: http://www.math.utah.edu/~beebe/software/ieee/tanh.pdf
