### PR TITLE
Update NetNode

### DIFF
--- a/Source/Evaluator.swift
+++ b/Source/Evaluator.swift
@@ -73,7 +73,7 @@ public class Evaluator {
                 guard let buffer = instance.buffers[netBuffer.id] else {
                     fatalError("Output buffer for \(dataLayer.name) not found.")
                 }
-                fillBuffer(buffer, start: n.outputOffset, withElements: dataLayer.nextBatch(1))
+                fillBuffer(buffer, start: n.outputRange.startIndex, withElements: dataLayer.nextBatch(1))
             }
             instance.closeNode(n)
             instance.openOutputsOf(n)
@@ -111,9 +111,9 @@ public class Evaluator {
             forwardLayer.encodeForwardInBuffer(buffer,
                                                batchSize: 1,
                                                input: inputBuffer,
-                                               offset: node.inputOffset,
+                                               offset: node.inputRange.startIndex,
                                                output: outputBuffer,
-                                               offset: node.outputOffset)
+                                               offset: node.outputRange.startIndex)
 
             buffer.addCompletedHandler() { commandBuffer in
                 dispatch_async(self.queue) {
@@ -137,7 +137,7 @@ public class Evaluator {
                     fatalError("Layer '\(n.layer.name)'s input buffer was not found.")
                 }
 
-                sinkLayer.consume(valueArrayFromBuffer(buffer, start: n.inputOffset))
+                sinkLayer.consume(valueArrayFromBuffer(buffer, start: n.inputRange.startIndex))
             }
         }
 

--- a/Source/Net.swift
+++ b/Source/Net.swift
@@ -71,7 +71,7 @@ public class Net {
             addLayer(transposeLayer)
             let transposeNode = nodes[transposeLayer.id]!
             transposeNode.outputBuffer = dataNode.outputBuffer
-            transposeNode.outputOffset = dataNode.outputOffset
+            transposeNode.outputRange = dataNode.outputRange
 
             let dataNodeIndex = dataOutputBuffer.inputNodes.indexOf(dataNode)!
             dataOutputBuffer.inputNodes.removeAtIndex(dataNodeIndex)
@@ -122,7 +122,7 @@ public class Net {
 
     func connectNode(node: NetNode, toBuffer buffer: NetBuffer) {
         node.outputBuffer = buffer
-        node.outputOffset = buffer.inputSize
+        node.outputRange = buffer.inputSize..<buffer.inputSize + node.outputSize
         buffer.inputNodes.append(node)
     }
 
@@ -145,7 +145,7 @@ public class Net {
 
     func connectSplitBuffer(buffer: NetBuffer, toNode node: NetNode) {
         node.inputBuffer = buffer
-        node.inputOffset = buffer.outputSize
+        node.inputRange = buffer.outputSize..<buffer.outputSize + node.inputSize
         buffer.outputNodes.append(node)
     }
 
@@ -168,7 +168,7 @@ public class Net {
 
     func connectWholeBuffer(buffer: NetBuffer, toNode node: NetNode) {
         node.inputBuffer = buffer
-        node.inputOffset = 0
+        node.inputRange = 0..<node.inputSize
         buffer.outputNodes.append(node)
     }
 }

--- a/Source/NetBuffer.swift
+++ b/Source/NetBuffer.swift
@@ -14,21 +14,15 @@ class NetBuffer: Hashable {
     let name: String?
 
     var inputSize: Int {
-        return inputNodes.reduce(0) { currentValue, node in
-            if node.outputSize > 0 {
-                return currentValue + node.outputRange.count
-            }
-            preconditionFailure("Cannot costruct buffer from \(node.layer.dynamicType).")
-        }
+        return inputNodes.reduce(0, combine: { currentValue, node in
+            return max(currentValue, node.outputRange.endIndex)
+        })
     }
 
     var outputSize: Int {
-        return outputNodes.reduce(0) { currentValue, node in
-            if node.inputSize > 0 {
-                return currentValue + node.inputRange.count
-            }
-            preconditionFailure("Cannot costruct buffer from \(node.layer.dynamicType).")
-        }
+        return outputNodes.reduce(0, combine: { currentValue, node in
+            return max(currentValue, node.inputRange.endIndex)
+        })
     }
 
     var size: Int {

--- a/Source/NetBuffer.swift
+++ b/Source/NetBuffer.swift
@@ -15,10 +15,8 @@ class NetBuffer: Hashable {
 
     var inputSize: Int {
         return inputNodes.reduce(0) { currentValue, node in
-            if let forwardLayer = node.layer as? ForwardLayer {
-                return currentValue + forwardLayer.outputSize
-            } else if let dataLayer = node.layer as? DataLayer {
-                return currentValue + dataLayer.outputSize
+            if node.outputSize > 0 {
+                return currentValue + node.outputRange.count
             }
             preconditionFailure("Cannot costruct buffer from \(node.layer.dynamicType).")
         }
@@ -26,10 +24,8 @@ class NetBuffer: Hashable {
 
     var outputSize: Int {
         return outputNodes.reduce(0) { currentValue, node in
-            if let forwardLayer = node.layer as? ForwardLayer {
-                return currentValue + forwardLayer.inputSize
-            } else if let sinkLayer = node.layer as? SinkLayer {
-                return currentValue + sinkLayer.inputSize
+            if node.inputSize > 0 {
+                return currentValue + node.inputRange.count
             }
             preconditionFailure("Cannot costruct buffer from \(node.layer.dynamicType).")
         }

--- a/Source/NetNode.swift
+++ b/Source/NetNode.swift
@@ -9,10 +9,28 @@ class NetNode: Hashable {
     let layer: Layer
 
     weak var inputBuffer: NetBuffer?
-    var inputOffset = 0
+    var inputRange = 0...0
 
     weak var outputBuffer: NetBuffer?
-    var outputOffset = 0
+    var outputRange = 0...0
+
+    var inputSize: Int {
+        if let forwardLayer = layer as? ForwardLayer {
+            return forwardLayer.inputSize
+        } else if let sinkLayer = layer as? SinkLayer {
+            return sinkLayer.inputSize
+        }
+        return 0
+    }
+
+    var outputSize: Int {
+        if let forwardLayer = layer as? ForwardLayer {
+            return forwardLayer.outputSize
+        } else if let dataLayer = layer as? DataLayer {
+            return dataLayer.outputSize
+        }
+        return 0
+    }
 
     init(layer: Layer) {
         self.layer = layer

--- a/Source/Snapshot.swift
+++ b/Source/Snapshot.swift
@@ -60,8 +60,8 @@ public class Snapshot {
                 return nil
         }
         let pointer = UnsafeMutablePointer<Float>(buffer.contents())
-        let count = buffer.length / sizeof(Float) - node.outputOffset
-        return UnsafeMutableBufferPointer(start: pointer + node.outputOffset, count: count)
+        let count = buffer.length / sizeof(Float) - node.outputRange.startIndex
+        return UnsafeMutableBufferPointer(start: pointer + node.outputRange.startIndex, count: count)
     }
 
     /// Return a pointer to the forward-pass input of a layer. The pointer is short-lived, you should copy any contents that you want preserve.
@@ -72,8 +72,8 @@ public class Snapshot {
                 return nil
         }
         let pointer = UnsafeMutablePointer<Float>(buffer.contents())
-        let count = buffer.length / sizeof(Float) - node.inputOffset
-        return UnsafeMutableBufferPointer(start: pointer + node.inputOffset, count: count)
+        let count = buffer.length / sizeof(Float) - node.inputRange.startIndex
+        return UnsafeMutableBufferPointer(start: pointer + node.inputRange.startIndex, count: count)
     }
 
     /// Return a pointer to the backward-pass input deltas of a layer. The pointer is short-lived, you should copy any contents that you want preserve.
@@ -84,8 +84,8 @@ public class Snapshot {
                 return nil
         }
         let pointer = UnsafeMutablePointer<Float>(buffer.contents())
-        let count = buffer.length / sizeof(Float) - node.inputOffset
-        return UnsafeMutableBufferPointer(start: pointer + node.inputOffset, count: count)
+        let count = buffer.length / sizeof(Float) - node.inputRange.startIndex
+        return UnsafeMutableBufferPointer(start: pointer + node.inputRange.startIndex, count: count)
     }
 
     /// Return a pointer to the backward-pass output deltas of a layer. The pointer is short-lived, you should copy any contents that you want preserve.
@@ -96,7 +96,7 @@ public class Snapshot {
                 return nil
         }
         let pointer = UnsafeMutablePointer<Float>(buffer.contents())
-        let count = buffer.length / sizeof(Float) - node.outputOffset
-        return UnsafeMutableBufferPointer(start: pointer + node.outputOffset, count: count)
+        let count = buffer.length / sizeof(Float) - node.outputRange.startIndex
+        return UnsafeMutableBufferPointer(start: pointer + node.outputRange.startIndex, count: count)
     }
 }

--- a/Source/Trainer.swift
+++ b/Source/Trainer.swift
@@ -80,7 +80,7 @@ public class Trainer {
                 guard let buffer = forwardInstance.buffers[netBuffer.id] else {
                     fatalError("Output buffer for \(dataLayer.name) not found.")
                 }
-                fillBuffer(buffer, start: batchSize * n.outputOffset, withElements: dataLayer.nextBatch(batchSize))
+                fillBuffer(buffer, start: batchSize * n.outputRange.startIndex, withElements: dataLayer.nextBatch(batchSize))
             }
             forwardInstance.closeNode(n)
             forwardInstance.openOutputsOf(n)
@@ -120,9 +120,9 @@ public class Trainer {
             forwardLayer.encodeForwardInBuffer(buffer,
                                                batchSize: batchSize,
                                                input: inputBuffer,
-                                               offset: batchSize * node.inputOffset,
+                                               offset: batchSize * node.inputRange.startIndex,
                                                output: outputBuffer,
-                                               offset: batchSize * node.outputOffset)
+                                               offset: batchSize * node.outputRange.startIndex)
 
             buffer.addCompletedHandler() { commandBuffer in
                 dispatch_async(self.queue) {


### PR DESCRIPTION
Add input and output ranges instead of offsets. This will allow us to properly compute Buffer sizes in instances of splitting with overlap.
